### PR TITLE
fix: Update image tag from v0.0.0 to v0.5.1

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: questdb/questdb-operator
-  newTag: v0.0.0
+  newTag: v0.5.1


### PR DESCRIPTION
The kustomization.yaml file was using a placeholder v0.0.0 tag which causes deployment issues when using GitOps tools like ArgoCD. This commit updates the image tag to use the actual release version v0.5.1.

This fixes the issue where ArgoCD would try to pull a non-existent or outdated v0.0.0 image when deploying the operator from the git repository.